### PR TITLE
Support multiple streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ These are the only official download mirrors. Any downloads besides of these lin
 > [!TIP]
 >  If needed, you can copy-paste the names of the Channel Points Rewards into a text document for later use.
   
-3. Set your [config.yml](core/src/main/resources/config.yml) up. Adjust the settings and add and setup the actions for rewards, donations... You will need to link a Twitch account in order to connect use the Twitch API (the linked account **needs to own/moderate all Twitch channels** set in config.yml) There are two ways to link your Twitch account to the plugin:  
+3. Set your [config.yml](core/src/main/resources/config.yml) up. Adjust the settings and setup events for rewards, donations... You will need to link a Twitch account in order to connect use the Twitch API (the linked account **needs to own/moderate all Twitch channels** set in config.yml) There are two ways to link your Twitch account to the plugin:  
 
     - **Using a key-based authentication** *(recommended)*:  
     You will need a Client ID and Access token. You can get one mannually or through a website as [Twitch Token Generator](https://twitchtokengenerator.com). Make sure to add all the [needed scopes](#twitch-scopes).  
@@ -45,7 +45,7 @@ These are the only official download mirrors. Any downloads besides of these lin
 ## **config.yml docs**
 To reset the original configuration, delete `config.yml` and reload the plugin. The file will regenerate automatically.  
 *Sections with a (\*) are required to be changed in order to the plugin to be used.*
-* **Channel Username***: The channel(s) that will be listened for rewards, bits and subs. (In case of multiple channels, they muse be added as a list: `["channel_1", "channel_2", "..."]`)  
+* **Channel Username***: The channel(s) that will be listened for rewards, bits and subs. (In case of multiple channels, they must be added as a list: `["channel_1", "channel_2", "..."]`)  
 * **Custom Client ID**: Client ID used for key-based authorization. Leave commented if it's not being used.  
 * **Custom Access Token**: Access token used for key-based authorization. Leave commented if it's not being used.  
 * **Show Chat**: If enabled, your stream chat will be shown in-game to all players in the server.  
@@ -110,7 +110,7 @@ Currently, there are 2 types of actions:
 > Argument names surrounded by <> means that it is a required argument.
 > Arguments surrounded by [] are optional.
 
-You should set up your events in your config file with this format:
+You should set up your events in your config file following this format:
 ```
 TYPE_REWARDS:
     - KEY:
@@ -118,9 +118,24 @@ TYPE_REWARDS:
         - Action 2
         - ...
 ```
+or
+```
+TYPE_REWARDS:
+    - KEY:
+        - STREAMER:
+            - Action 1
+            - Action 2
+            - ...
+
+        - default:
+            - Action
+```
 Whereas `TYPE_REWARDS` is replaces with the appropiate config key that is already on the file, `KEY` with the channel points reward name, subscription tier or minimal amount of bits/subs.  
 > [!IMPORTANT]  
-> **For follow events this line should be ommited.** See the placeholders on the default [config.yml](core/src/main/resources/config.yml).
+> **For follow events you shouldn't add reward keys.** See placeholders on the default [config.yml](core/src/main/resources/config.yml).
+
+> [!TIP]
+> You can now target multiple channels. If you do so, you can target some events to a specific channel following the second format. You can still follow the first example if you don't aim to target specific channels. 
 
 ## Twitch Scopes
 The latest version of the plugin needs the following scopes to function propertly:  

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ These are the only official download mirrors. Any downloads besides of these lin
 > [!TIP]
 >  If needed, you can copy-paste the names of the Channel Points Rewards into a text document for later use.
   
-3. Set your [config.yml](core/src/main/resources/config.yml) up. Adjust the settings and add and setup the actions for rewards, donations... There are two ways to link your Twitch account to the plugin:  
+3. Set your [config.yml](core/src/main/resources/config.yml) up. Adjust the settings and add and setup the actions for rewards, donations... You will need to link a Twitch account in order to connect use the Twitch API (the linked account **needs to own/moderate all Twitch channels** set in config.yml) There are two ways to link your Twitch account to the plugin:  
 
     - **Using a key-based authentication** *(recommended)*:  
     You will need a Client ID and Access token. You can get one mannually or through a website as [Twitch Token Generator](https://twitchtokengenerator.com). Make sure to add all the [needed scopes](#twitch-scopes).  
@@ -30,7 +30,7 @@ These are the only official download mirrors. Any downloads besides of these lin
     - **Log in through a browser**:  
     You won't need any extra modification in your config.yml file. You will just need to run `/twitch link` in-game and open the provided link. You may need to log in your Twitch account and authorise the app. Once you finish the log in process you can close the browser and your account will be linked.
 > [!WARNING]  
-> Currently due to technical limitations **it's only possible to use the browser method if the login link is opened with the same machine the server is being ran on**. You also have to repeat this process each time you start the server or reload the plugin.
+> Currently due to API limitations **it's only possible to use the browser method if the login link is opened with the same machine the server is being ran on**. You also have to repeat this process each time you start the server or reload the plugin.
 
 4. Set up permissions for:
     - linking/reloading (`chatpointsttv.manage`).
@@ -45,7 +45,7 @@ These are the only official download mirrors. Any downloads besides of these lin
 ## **config.yml docs**
 To reset the original configuration, delete `config.yml` and reload the plugin. The file will regenerate automatically.  
 *Sections with a (\*) are required to be changed in order to the plugin to be used.*
-* **Channel Username***: The channel that will be listened for rewards, bits and subs.  
+* **Channel Username***: The channel(s) that will be listened for rewards, bits and subs. (In case of multiple channels, they muse be added as a list: `["channel_1", "channel_2", "..."]`)  
 * **Custom Client ID**: Client ID used for key-based authorization. Leave commented if it's not being used.  
 * **Custom Access Token**: Access token used for key-based authorization. Leave commented if it's not being used.  
 * **Show Chat**: If enabled, your stream chat will be shown in-game to all players in the server.  

--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ The latest version of the plugin needs the following scopes to function propertl
 * `moderator:read:followers`: Needed to be able to listen for follows.
 * `bits:read`: Needed to listen for cheers.
 * `channel:read:subscriptions`: Needed to listen for subscriptions and gifts.
-* `user:read:chat`: Needed to use Twitch EventSub API.
-* `chat:read`: Needed to show your stream chat in-game.
+* `chat:read` and `user:read:chat`: Needed to show your stream chat in-game and use EventSub API.
+* `user:bot` and `channel:bot`: Joins a stream chat to listen for subs.
 
 ## Permissions
 - TARGET  

--- a/core/src/main/java/me/gosdev/chatpointsttv/ChatPointsTTV.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/ChatPointsTTV.java
@@ -439,27 +439,23 @@ public class ChatPointsTTV extends JavaPlugin {
         
         if (Rewards.getRewards(Rewards.rewardType.CHANNEL_POINTS) != null) {
             client.getPubSub().listenForChannelPointsRedemptionEvents(null, channel_id);
-            utils.sendMessage(Bukkit.getConsoleSender(), "Listening for " + channel + "'s channel point redemptions...");
         }
 
         if (Rewards.getRewards(Rewards.rewardType.FOLLOW) != null) {
             if (TwitchUtils.getModeratedChannelIDs(oauth.getAccessToken(), user_id).contains(channel_id) || user_id.equals(channel_id)) { // If account is the streamer or a mod (need to have mod permissions on the channel)
                 eventSocket.register(SubscriptionTypes.CHANNEL_FOLLOW_V2.prepareSubscription(b -> b.moderatorUserId(user_id).broadcasterUserId(channel_id).build(), null));
-                utils.sendMessage(Bukkit.getConsoleSender(), "Listening for " + channel + "'s follows...");            
             } else {
-                log.warning("Follow events cannot be listened to on unauthorised channels.");
+                log.warning(channel + ": Follow events cannot be listened to on unauthorised channels.");
                 latch.countDown();
             }
         } 
 
         if (Rewards.getRewards(Rewards.rewardType.CHEER) != null) {
             eventSocket.register(SubscriptionTypes.CHANNEL_CHAT_MESSAGE.prepareSubscription(b -> b.broadcasterUserId(channel_id).userId(user_id).build(), null));
-            utils.sendMessage(Bukkit.getConsoleSender(), "Listening for " + channel + "'s Cheers...");
         }
 
         if (Rewards.getRewards(Rewards.rewardType.SUB) != null || Rewards.getRewards(Rewards.rewardType.GIFT) != null) {
             eventSocket.register(SubscriptionTypes.CHANNEL_CHAT_NOTIFICATION.prepareSubscription(b -> b.broadcasterUserId(channel_id).userId(user_id).build(), null));
-            utils.sendMessage(Bukkit.getConsoleSender(), "Listening for " + channel + "'s subscriptions and gifts...");
         }
         utils.sendMessage(Bukkit.getConsoleSender(), "Listening to " + channel + "'s events...");
         client.getChat().joinChannel(channel);

--- a/core/src/main/java/me/gosdev/chatpointsttv/ChatPointsTTV.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/ChatPointsTTV.java
@@ -94,7 +94,9 @@ public class ChatPointsTTV extends JavaPlugin {
         Scopes.BITS_READ,
         Scopes.CHANNEL_READ_SUBSCRIPTIONS,
         Scopes.USER_READ_CHAT,
-        Scopes.CHAT_READ
+        Scopes.CHAT_READ,
+        Scopes.USER_BOT,
+        Scopes.CHANNEL_BOT
         ).replace(":", "%3A"); // Format colon character for browser
 
     private OAuth2Credential oauth;
@@ -372,8 +374,7 @@ public class ChatPointsTTV extends JavaPlugin {
                     public void accept(ChannelChatNotificationEvent e) {
                         try { // May get NullPointerException if event is triggered while still subscribing
                             if (e.getNoticeType() == NoticeType.SUB || e.getNoticeType() == NoticeType.RESUB) eventHandler.onSub(e);
-                            else if (e.getNoticeType() == NoticeType.SUB_GIFT) eventHandler.onSubGift(e);
-                            else return;
+                            else if (e.getNoticeType() == NoticeType.COMMUNITY_SUB_GIFT || e.getNoticeType() == NoticeType.SUB_GIFT) eventHandler.onSubGift(e);
                         } catch (NullPointerException ex) {}
                     }
                 });

--- a/core/src/main/java/me/gosdev/chatpointsttv/ChatPointsTTV.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/ChatPointsTTV.java
@@ -374,7 +374,7 @@ public class ChatPointsTTV extends JavaPlugin {
                     public void accept(ChannelChatNotificationEvent e) {
                         try { // May get NullPointerException if event is triggered while still subscribing
                             if (e.getNoticeType() == NoticeType.SUB || e.getNoticeType() == NoticeType.RESUB) eventHandler.onSub(e);
-                            else if (e.getNoticeType() == NoticeType.COMMUNITY_SUB_GIFT || e.getNoticeType() == NoticeType.SUB_GIFT) eventHandler.onSubGift(e);
+                            else if (e.getNoticeType() == NoticeType.COMMUNITY_SUB_GIFT) eventHandler.onSubGift(e);
                         } catch (NullPointerException ex) {}
                     }
                 });

--- a/core/src/main/java/me/gosdev/chatpointsttv/ChatPointsTTV.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/ChatPointsTTV.java
@@ -146,13 +146,11 @@ public class ChatPointsTTV extends JavaPlugin {
     public String getConnectedUsername() {
         return accountConnected ? user.getLogin() : "Not Linked";
     }
-    public String getListenedChannel() {
-        if (plugin != null) {
-            return client.getChat().getChannels().iterator().next(); // UNTESTED 
-        } else {
-            if (plugin.config.getString("TWITCH_CHANNEL_USERNAME") == null | plugin.config.getString("TWITCH_CHANNEL_USERNAME").startsWith("MemorySection[path=")) return null; // Invalid string (probably left default "{YOUR CHANNEL}")) return null;
-            return plugin.config.getString("TWITCH_CHANNEL_USERNAME");
-        }
+    public List<String> getListenedChannels() {
+        List<String> channels = new ArrayList<>();
+        if (plugin.config.getStringList("CHANNEL_USERNAME") != null) channels = plugin.config.getStringList("CHANNEL_USERNAME");
+        else channels.add(plugin.config.getString("CHANNEL_USERNAME"));
+        return channels;
     }
 
     private static Utils utils;

--- a/core/src/main/java/me/gosdev/chatpointsttv/ChatPointsTTV.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/ChatPointsTTV.java
@@ -35,6 +35,7 @@ import com.github.twitch4j.chat.events.channel.ChannelMessageEvent;
 import com.github.twitch4j.eventsub.events.ChannelChatMessageEvent;
 import com.github.twitch4j.eventsub.events.ChannelChatNotificationEvent;
 import com.github.twitch4j.eventsub.events.ChannelFollowEvent;
+import com.github.twitch4j.eventsub.events.ChannelSubscriptionGiftEvent;
 import com.github.twitch4j.eventsub.socket.IEventSubSocket;
 import com.github.twitch4j.eventsub.socket.events.EventSocketSubscriptionFailureEvent;
 import com.github.twitch4j.eventsub.socket.events.EventSocketSubscriptionSuccessEvent;
@@ -87,6 +88,7 @@ public class ChatPointsTTV extends JavaPlugin {
     private final static String ClientID = "1peexftcqommf5tf5pt74g7b3gyki3";
     public final String scopes = Scopes.join(
         Scopes.CHANNEL_READ_REDEMPTIONS,
+        Scopes.CHANNEL_READ_SUBSCRIPTIONS,
         Scopes.USER_READ_MODERATED_CHANNELS,
         Scopes.MODERATOR_READ_FOLLOWERS,
         Scopes.BITS_READ,
@@ -373,6 +375,13 @@ public class ChatPointsTTV extends JavaPlugin {
                         } catch (NullPointerException ex) {}
                     }
                 });
+                eventManager.onEvent(ChannelSubscriptionGiftEvent.class, new Consumer<ChannelSubscriptionGiftEvent>() {
+                    @Override
+                    public void accept(ChannelSubscriptionGiftEvent e) {
+                        log.info(e.getUserName());
+                        log.info(e.getTotal() + " subs");
+                    }
+                });
             }
             if (config.getBoolean("SHOW_CHAT")) {
                 eventManager.onEvent(ChannelMessageEvent.class, event -> {
@@ -456,6 +465,7 @@ public class ChatPointsTTV extends JavaPlugin {
 
         if (Rewards.getRewards(Rewards.rewardType.SUB) != null || Rewards.getRewards(Rewards.rewardType.GIFT) != null) {
             eventSocket.register(SubscriptionTypes.CHANNEL_CHAT_NOTIFICATION.prepareSubscription(b -> b.broadcasterUserId(channel_id).userId(user_id).build(), null));
+            eventSocket.register(SubscriptionTypes.CHANNEL_SUBSCRIPTION_GIFT.prepareSubscription(b -> b.broadcasterUserId(channel_id).build(), null));
         }
         utils.sendMessage(Bukkit.getConsoleSender(), "Listening to " + channel + "'s events...");
         client.getChat().joinChannel(channel);

--- a/core/src/main/java/me/gosdev/chatpointsttv/ChatPointsTTV.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/ChatPointsTTV.java
@@ -78,7 +78,6 @@ public class ChatPointsTTV extends JavaPlugin {
     public Thread linkThread;
 
     private String user_id;
-    private String channel_id;
 
     public Logger log = getLogger();
     public FileConfiguration config;
@@ -314,106 +313,22 @@ public class ChatPointsTTV extends JavaPlugin {
             }
             
             utils.sendMessage(Bukkit.getConsoleSender(), "Logged in as: "+ user.getDisplayName());
-    
-            // Join the twitch chat of this channel and enable stream/follow events
-            String channel = config.getString("CHANNEL_USERNAME");
-            channel_id = getUserId(channel);
-            user_id = new TwitchIdentityProvider(null, null, null).getAdditionalCredentialInformation(oauth).map(OAuth2Credential::getUserId).orElse(null);
-            utils.sendMessage(Bukkit.getConsoleSender(), "Listening to " + channel + "'s events...");
-            client.getChat().joinChannel(channel);
-    
-            // Subscribe to events
-            eventSocket = client.getEventSocket();
-            eventManager = client.getEventManager();
 
-            CountDownLatch latch = new CountDownLatch(3);
-            eventManager.onEvent(EventSocketSubscriptionSuccessEvent.class, e -> latch.countDown());
-            eventManager.onEvent(EventSocketSubscriptionFailureEvent.class, e -> latch.countDown());
-            
-            if (Rewards.getRewards(Rewards.rewardType.CHANNEL_POINTS) != null) {
-                client.getPubSub().listenForChannelPointsRedemptionEvents(null, channel_id);
-                eventManager.onEvent(RewardRedeemedEvent.class, new Consumer<RewardRedeemedEvent>() {
-                    @Override
-                    public void accept(RewardRedeemedEvent e) {
-                        eventHandler.onChannelPointsRedemption(e);
-                    }
-                });
-                utils.sendMessage(Bukkit.getConsoleSender(), "Listening for channel point rewards...");
-            }
-            if (Rewards.getRewards(Rewards.rewardType.FOLLOW) != null) {
-                if (TwitchUtils.getModeratedChannelIDs(oauth.getAccessToken(), user_id).contains(channel_id) || user_id.equals(channel_id)) { // If account is the streamer or a mod (need to have mod permissions on the channel)
-                    eventSocket.register(SubscriptionTypes.CHANNEL_FOLLOW_V2.prepareSubscription(b -> b.moderatorUserId(user_id).broadcasterUserId(channel_id).build(), null));
-                    eventManager.onEvent(ChannelFollowEvent.class, new Consumer<ChannelFollowEvent>() {
-                        @Override
-                        public void accept(ChannelFollowEvent e) {
-                            try { // May get NullPointerException if event is triggered while still subscribing
-                                eventHandler.onFollow(e);
-                            } catch (NullPointerException ex) {}
-                        }
-                    });
-                    utils.sendMessage(Bukkit.getConsoleSender(), "Listening for follows...");            
-                } else {
-                    log.warning("Follow events cannot be listened to on unauthorised channels.");
-                }
-            } else latch.countDown();
-
-            if (Rewards.getRewards(Rewards.rewardType.CHEER) != null) {
-                eventSocket.register(SubscriptionTypes.CHANNEL_CHAT_MESSAGE.prepareSubscription(b -> b.broadcasterUserId(channel_id).userId(user_id).build(), null));
-                eventManager.onEvent(ChannelChatMessageEvent.class, new Consumer<ChannelChatMessageEvent>() {
-                    @Override
-                    public void accept(ChannelChatMessageEvent e) {
-                        try { // May get NullPointerException if event is triggered while still subscribing
-                            eventHandler.onCheer(e);
-                        } catch (NullPointerException ex) {}
-                    }
-                }); 
-                utils.sendMessage(Bukkit.getConsoleSender(), "Listening for Cheers...");
-            } else latch.countDown();
-    
-            if (Rewards.getRewards(Rewards.rewardType.SUB) != null || Rewards.getRewards(Rewards.rewardType.GIFT) != null) {
-                eventSocket.register(SubscriptionTypes.CHANNEL_CHAT_NOTIFICATION.prepareSubscription(b -> b.broadcasterUserId(channel_id).userId(user_id).build(), null));
-                eventManager.onEvent(ChannelChatNotificationEvent.class, new Consumer<ChannelChatNotificationEvent>(){
-                    @Override
-                    public void accept(ChannelChatNotificationEvent e) {
-                        try { // May get NullPointerException if event is triggered while still subscribing
-                            eventHandler.onEvent(e);
-                        } catch (NullPointerException ex) {}
-                    }
-                });
-                utils.sendMessage(Bukkit.getConsoleSender(), "Listening for subscriptions and gifts...");
-            } else latch.countDown();
-    
-            if (config.getBoolean("SHOW_CHAT")) {
-                eventManager.onEvent(ChannelMessageEvent.class, event -> {
-                    if (!chatBlacklist.contains(event.getUser().getName())) {
-                        net.md_5.bungee.api.ChatColor mcColor;
-                        try {
-                            mcColor = ColorUtils.getClosestChatColor(new Color(ColorUtils.hexToRgb(event.getMessageEvent().getUserChatColor().get())));
-                        } catch (Exception e) {
-                            mcColor = net.md_5.bungee.api.ChatColor.RED; 
-                        }
-                        BaseComponent[] components = new BaseComponent[] {
-                            new ComponentBuilder(mcColor + event.getMessageEvent().getUserDisplayName().get() + ": ").create()[0],
-                            new ComponentBuilder(event.getMessage()).create()[0]
-                        };
-                        for (Player player : Bukkit.getOnlinePlayers()) {
-                            if (player.hasPermission(permissions.BROADCAST.permission_id)) {
-                                utils.sendMessage(player, components);
-                            }
-                        }
-                    }
-                });
-            }
             eventHandler = new TwitchEventHandler();
-            client.getEventManager().getEventHandler(SimpleEventHandler.class).registerListener(eventHandler);
-            utils.sendMessage(p, "Twitch client was started successfully!");
-            
-            try {
-                latch.await();
-            } catch (InterruptedException e1) {
-                e1.printStackTrace();
-            }
 
+            // Linked account UserID
+            user_id = new TwitchIdentityProvider(null, null, null).getAdditionalCredentialInformation(oauth).map(OAuth2Credential::getUserId).orElse(null);
+
+            // Join the twitch chat of this channel(s) and enable stream/follow events
+            if (config.getList("CHANNEL_USERNAME") == null) {                
+                subscribeToEvents(p, config.getString("CHANNEL_USERNAME"));
+            } else {
+                for (String channel : config.getStringList("CHANNEL_USERNAME")) {
+                    subscribeToEvents(p, channel);
+                }
+            }    
+
+            utils.sendMessage(p, "Twitch client was started successfully!");
             accountConnected = true;
         });
         linkThread.start();
@@ -428,7 +343,99 @@ public class ChatPointsTTV extends JavaPlugin {
             }
         });
     }
+    
+    public void subscribeToEvents(CommandSender p, String channel) {
+        String channel_id = getUserId(channel);
+        eventSocket = client.getEventSocket();
+        eventManager = client.getEventManager();
 
+        CountDownLatch latch = new CountDownLatch(3);
+        eventManager.onEvent(EventSocketSubscriptionSuccessEvent.class, e -> latch.countDown());
+        eventManager.onEvent(EventSocketSubscriptionFailureEvent.class, e -> latch.countDown());
+        
+        if (Rewards.getRewards(Rewards.rewardType.CHANNEL_POINTS) != null) {
+            client.getPubSub().listenForChannelPointsRedemptionEvents(null, channel_id);
+            eventManager.onEvent(RewardRedeemedEvent.class, new Consumer<RewardRedeemedEvent>() {
+                @Override
+                public void accept(RewardRedeemedEvent e) {
+                    eventHandler.onChannelPointsRedemption(e);
+                }
+            });
+            utils.sendMessage(Bukkit.getConsoleSender(), "Listening for " + channel + "'s channel point redemptions...");
+        }
+        if (Rewards.getRewards(Rewards.rewardType.FOLLOW) != null) {
+            if (TwitchUtils.getModeratedChannelIDs(oauth.getAccessToken(), user_id).contains(channel_id) || user_id.equals(channel_id)) { // If account is the streamer or a mod (need to have mod permissions on the channel)
+                eventSocket.register(SubscriptionTypes.CHANNEL_FOLLOW_V2.prepareSubscription(b -> b.moderatorUserId(user_id).broadcasterUserId(channel_id).build(), null));
+                eventManager.onEvent(ChannelFollowEvent.class, new Consumer<ChannelFollowEvent>() {
+                    @Override
+                    public void accept(ChannelFollowEvent e) {
+                        try { // May get NullPointerException if event is triggered while still subscribing
+                            eventHandler.onFollow(e);
+                        } catch (NullPointerException ex) {}
+                    }
+                });
+                utils.sendMessage(Bukkit.getConsoleSender(), "Listening for " + channel + "'s follows...");            
+            } else {
+                log.warning("Follow events cannot be listened to on unauthorised channels.");
+            }
+        } else latch.countDown();
+
+        if (Rewards.getRewards(Rewards.rewardType.CHEER) != null) {
+            eventSocket.register(SubscriptionTypes.CHANNEL_CHAT_MESSAGE.prepareSubscription(b -> b.broadcasterUserId(channel_id).userId(user_id).build(), null));
+            eventManager.onEvent(ChannelChatMessageEvent.class, new Consumer<ChannelChatMessageEvent>() {
+                @Override
+                public void accept(ChannelChatMessageEvent e) {
+                    try { // May get NullPointerException if event is triggered while still subscribing
+                        eventHandler.onCheer(e);
+                    } catch (NullPointerException ex) {}
+                }
+            }); 
+            utils.sendMessage(Bukkit.getConsoleSender(), "Listening for " + channel + "'s Cheers...");
+        } else latch.countDown();
+
+        if (Rewards.getRewards(Rewards.rewardType.SUB) != null || Rewards.getRewards(Rewards.rewardType.GIFT) != null) {
+            eventSocket.register(SubscriptionTypes.CHANNEL_CHAT_NOTIFICATION.prepareSubscription(b -> b.broadcasterUserId(channel_id).userId(user_id).build(), null));
+            eventManager.onEvent(ChannelChatNotificationEvent.class, new Consumer<ChannelChatNotificationEvent>(){
+                @Override
+                public void accept(ChannelChatNotificationEvent e) {
+                    try { // May get NullPointerException if event is triggered while still subscribing
+                        eventHandler.onEvent(e);
+                    } catch (NullPointerException ex) {}
+                }
+            });
+            utils.sendMessage(Bukkit.getConsoleSender(), "Listening for " + channel + "'s subscriptions and gifts...");
+        } else latch.countDown();
+
+        if (config.getBoolean("SHOW_CHAT")) {
+            eventManager.onEvent(ChannelMessageEvent.class, event -> {
+                if (!chatBlacklist.contains(event.getUser().getName())) {
+                    net.md_5.bungee.api.ChatColor mcColor;
+                    try {
+                        mcColor = ColorUtils.getClosestChatColor(new Color(ColorUtils.hexToRgb(event.getMessageEvent().getUserChatColor().get())));
+                    } catch (Exception e) {
+                        mcColor = net.md_5.bungee.api.ChatColor.RED; 
+                    }
+                    BaseComponent[] components = new BaseComponent[] {
+                        new ComponentBuilder(mcColor + event.getMessageEvent().getUserDisplayName().get() + ": ").create()[0],
+                        new ComponentBuilder(event.getMessage()).create()[0]
+                    };
+                    for (Player player : Bukkit.getOnlinePlayers()) {
+                        if (player.hasPermission(permissions.BROADCAST.permission_id)) {
+                            utils.sendMessage(player, components);
+                        }
+                    }
+                }
+            });
+        }
+        client.getEventManager().getEventHandler(SimpleEventHandler.class).registerListener(eventHandler);
+        utils.sendMessage(Bukkit.getConsoleSender(), "Listening to " + channel + "'s events...");
+        client.getChat().joinChannel(channel);        
+        try {
+            latch.await();
+        } catch (InterruptedException e1) {
+            log.warning("Failed to listen to " + channel + "'s events. Channel may not exist or the linked account may lack permissions.");
+        }
+    }
     public void unlink(CommandSender p) {
         if (!accountConnected) {
             p.sendMessage(ChatColor.RED + "There is no connected account.");

--- a/core/src/main/java/me/gosdev/chatpointsttv/ChatPointsTTV.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/ChatPointsTTV.java
@@ -387,10 +387,9 @@ public class ChatPointsTTV extends JavaPlugin {
             }
 
             CountDownLatch latch = new CountDownLatch(subs * channels);
-            log.info(String.valueOf(subs * channels));
 
-            eventManager.onEvent(EventSocketSubscriptionSuccessEvent.class, e -> {latch.countDown(); log.info(e.toString());});
-            eventManager.onEvent(EventSocketSubscriptionFailureEvent.class, e -> {latch.countDown(); log.info("sub error");});
+            eventManager.onEvent(EventSocketSubscriptionSuccessEvent.class, e -> latch.countDown());
+            eventManager.onEvent(EventSocketSubscriptionFailureEvent.class, e -> latch.countDown());
 
             // Join the twitch chat of this channel(s) and enable stream/follow events
             if (config.getList("CHANNEL_USERNAME") == null) { // If field is not a list (single channel)            

--- a/core/src/main/java/me/gosdev/chatpointsttv/ChatPointsTTV.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/ChatPointsTTV.java
@@ -114,8 +114,18 @@ public class ChatPointsTTV extends JavaPlugin {
     }
 
     public String getUserId(String username) {
-        UserList resultList = getTwitchClient().getHelix().getUsers(null, null, Arrays.asList(username)).execute();
+        UserList resultList = getTwitchClient().getHelix().getUsers(oauth.getAccessToken(), null, Arrays.asList(username)).execute();
+        if (resultList.getUsers().isEmpty()) {
+            throw new NullPointerException("Couldn't fetch user: " + username);
+        }
         return resultList.getUsers().get(0).getId();
+    }
+    public String getUsername(String userId) {
+        UserList resultList = client.getHelix().getUsers(oauth.getAccessToken(), Arrays.asList(userId), null).execute();
+        if (resultList.getUsers().isEmpty()) {
+            throw new NullPointerException("Couldn't fetch user ID: " + userId);
+        }
+        return resultList.getUsers().get(0).getDisplayName();
     }
 
     public static ITwitchClient getTwitchClient() {

--- a/core/src/main/java/me/gosdev/chatpointsttv/CommandController.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/CommandController.java
@@ -144,11 +144,17 @@ public class CommandController implements TabExecutor {
     }
 
     private void status(CommandSender p, ChatPointsTTV plugin) {
+        List<String> channels = plugin.getListenedChannels();
+        String strChannels = "";
+        for (int i = 0; i < channels.size(); i++) {
+            strChannels += channels.get(i);
+            if (i != channels.size() - 1) strChannels += ", ";
+        }
         String msg = (
             "---------- " + ChatColor.DARK_PURPLE + ChatColor.BOLD  + "ChatPointsTTV status" + ChatColor.RESET + " ----------\n" + 
             ChatColor.LIGHT_PURPLE + "Plugin version: " + ChatColor.RESET + "v" +plugin.getDescription().getVersion() + "\n" +
             ChatColor.LIGHT_PURPLE + "Connected account: " + ChatColor.RESET + plugin.getConnectedUsername() + "\n" +
-            ChatColor.LIGHT_PURPLE + "Listened channel: " + ChatColor.RESET + plugin.getListenedChannel() + "\n" + 
+            ChatColor.LIGHT_PURPLE + "Listened channels: " + ChatColor.RESET + strChannels + "\n" + 
             "\n" +
             ChatColor.LIGHT_PURPLE + "Connection status: " + (plugin.isAccountConnected() ? ChatColor.GREEN + "" + ChatColor.BOLD + "ACTIVE" : ChatColor.RED + "" + ChatColor.BOLD + "DISCONNECTED")
         );

--- a/core/src/main/java/me/gosdev/chatpointsttv/Rewards/Reward.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/Rewards/Reward.java
@@ -2,15 +2,22 @@ package me.gosdev.chatpointsttv.Rewards;
 
 import java.util.List;
 
+import me.gosdev.chatpointsttv.ChatPointsTTV;
 import me.gosdev.chatpointsttv.Rewards.Rewards.rewardType;
 
 public class Reward {
     rewardType type;
     private String event;
     private List<String> cmds;
+    private String channel;
+    private String channelId;
 
-    public Reward (rewardType type, String event, List<String> cmds) {
+    public Reward (rewardType type, String channel, String event, List<String> cmds) {
         this.type = type;
+        this.channel = channel;
+        
+        channelId = channel.equals(Rewards.EVERYONE) ? "*" : ChatPointsTTV.getPlugin().getUserId(channel);
+
         this.event = event;
         this.cmds = cmds;
     }
@@ -23,5 +30,11 @@ public class Reward {
     }
     public rewardType getType() {
         return type;
+    }
+    public String getChannel() {
+        return channel;
+    }
+    public String getTargetId() {
+        return channelId;
     }
 }

--- a/core/src/main/java/me/gosdev/chatpointsttv/Rewards/RewardComparator.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/Rewards/RewardComparator.java
@@ -19,7 +19,7 @@ public class RewardComparator implements Comparator<Reward> {
         });
 
 
-        return Integer.parseInt(o1.getEvent()) - Integer.parseInt(o2.getEvent());
+        return Integer.parseInt(o2.getEvent()) - Integer.parseInt(o1.getEvent());
     }
 
 }

--- a/core/src/main/java/me/gosdev/chatpointsttv/Rewards/RewardComparator.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/Rewards/RewardComparator.java
@@ -2,20 +2,22 @@ package me.gosdev.chatpointsttv.Rewards;
 
 import java.util.Comparator;
 
-import me.gosdev.chatpointsttv.Rewards.Rewards.rewardType;
-
 public class RewardComparator implements Comparator<Reward> {
     @Override
     public int compare(Reward o1, Reward o2) {
         if (o1.getType() != o2.getType()) throw new java.lang.UnsupportedOperationException("Cannot compare " + o1.getType().toString() + " rewards with " + o2.getType().toString());
 
-        if (o1.getChannel().equals(Rewards.EVERYONE) && !o2.getChannel().equals(Rewards.EVERYONE)) return 1;
-        if (o2.getChannel().equals(Rewards.EVERYONE) && !o1.getChannel().equals(Rewards.EVERYONE)) return -1;
+        try {
+            int difference = Integer.parseInt(o2.getEvent()) - Integer.parseInt(o1.getEvent());
 
-        if (o1.getType() == rewardType.CHANNEL_POINTS || o1.getType() == rewardType.FOLLOW || o1.getType() == rewardType.SUB) return 0;
-        if (o2.getType() == rewardType.CHANNEL_POINTS || o2.getType() == rewardType.FOLLOW || o2.getType() == rewardType.SUB) return 0;
+            if (difference == 0) throw new NumberFormatException(); // If value matches compare target channel (go straight to catch)
+            return difference;
+        } catch (NumberFormatException e) {
+            if (o1.getChannel().equals(Rewards.EVERYONE) && !o2.getChannel().equals(Rewards.EVERYONE)) return 1;
+            if (o2.getChannel().equals(Rewards.EVERYONE) && !o1.getChannel().equals(Rewards.EVERYONE)) return -1;
+            return 0;
+        }
 
-        return Integer.parseInt(o2.getEvent()) - Integer.parseInt(o1.getEvent());
     }
 
 }

--- a/core/src/main/java/me/gosdev/chatpointsttv/Rewards/RewardComparator.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/Rewards/RewardComparator.java
@@ -1,8 +1,6 @@
 package me.gosdev.chatpointsttv.Rewards;
 
-import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.List;
 
 import me.gosdev.chatpointsttv.Rewards.Rewards.rewardType;
 
@@ -10,14 +8,12 @@ public class RewardComparator implements Comparator<Reward> {
     @Override
     public int compare(Reward o1, Reward o2) {
         if (o1.getType() != o2.getType()) throw new java.lang.UnsupportedOperationException("Cannot compare " + o1.getType().toString() + " rewards with " + o2.getType().toString());
-        if (o1.getType() == rewardType.CHANNEL_POINTS || o1.getType() == rewardType.FOLLOW || o1.getType() == rewardType.SUB) throw new UnsupportedOperationException("Cannot sort " + o1.getType().toString() + " rewards.");
-        if (o2.getType() == rewardType.CHANNEL_POINTS || o2.getType() == rewardType.FOLLOW || o2.getType() == rewardType.SUB) throw new UnsupportedOperationException("Cannot sort " + o1.getType().toString() + " rewards.");
 
-        List<Integer> amounts = new ArrayList<Integer>();
-        Rewards.getRewards(rewardType.CHEER).forEach((reward) -> {
-            amounts.add(Integer.parseInt(reward.getEvent()));
-        });
+        if (o1.getChannel().equals(Rewards.EVERYONE) && !o2.getChannel().equals(Rewards.EVERYONE)) return 1;
+        if (o2.getChannel().equals(Rewards.EVERYONE) && !o1.getChannel().equals(Rewards.EVERYONE)) return -1;
 
+        if (o1.getType() == rewardType.CHANNEL_POINTS || o1.getType() == rewardType.FOLLOW || o1.getType() == rewardType.SUB) return 0;
+        if (o2.getType() == rewardType.CHANNEL_POINTS || o2.getType() == rewardType.FOLLOW || o2.getType() == rewardType.SUB) return 0;
 
         return Integer.parseInt(o2.getEvent()) - Integer.parseInt(o1.getEvent());
     }

--- a/core/src/main/java/me/gosdev/chatpointsttv/Rewards/Rewards.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/Rewards/Rewards.java
@@ -35,11 +35,13 @@ public class Rewards {
                 reward_list.add(new Reward(type, EVERYONE, null, config.getStringList(type.toString().toUpperCase() + "_REWARDS")));
             } else {
                 // Streamer specific events
+                if (config_rewards == null) return null;
                 Set<String> keys = config_rewards.getKeys(false);
                 for (String channel : keys) {
                     reward_list.add(new Reward(type, channel.equals("default") ? EVERYONE : channel, null, config_rewards.getStringList(channel)));
                 }
             }
+            reward_list.sort(new RewardComparator());
             rewards.put(type, reward_list);
             return reward_list;
 
@@ -59,7 +61,11 @@ public class Rewards {
                     }
                 }
             }
+            reward_list.sort(new RewardComparator());
             rewards.put(type, reward_list);
+            for (Reward reward : reward_list) {
+                ChatPointsTTV.getPlugin().log.info(reward.getChannel()+": " + reward.getEvent());
+            }
             return reward_list;
         }
 

--- a/core/src/main/java/me/gosdev/chatpointsttv/Rewards/Rewards.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/Rewards/Rewards.java
@@ -2,12 +2,11 @@ package me.gosdev.chatpointsttv.Rewards;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
 
 import me.gosdev.chatpointsttv.ChatPointsTTV;
 public class Rewards {
@@ -19,29 +18,51 @@ public class Rewards {
         GIFT
     };
 
+    public static final String EVERYONE = "*";
+
     public static Map<rewardType, ArrayList<Reward>> rewards = new HashMap<rewardType, ArrayList<Reward>>();
 
     public static ArrayList<Reward> getRewards(rewardType type) {
-        if (rewards.get(type) != null) return rewards.get(type); // Give stored dictionary if it was already fetched
+        //if (rewards.get(type) != null) return rewards.get(type); // Give stored dictionary if it was already fetched
+        FileConfiguration config = ChatPointsTTV.getPlugin().config;
 
-        ConfigurationSection config_value = ChatPointsTTV.getPlugin().config.getConfigurationSection(type.toString().toUpperCase() + "_REWARDS");
+        ConfigurationSection config_rewards = config.getConfigurationSection(type.toString().toUpperCase() + "_REWARDS");
         ArrayList<Reward> reward_list = new ArrayList<>();
-        if (type == rewardType.FOLLOW) {
-            List<String> follow_rewards = ChatPointsTTV.getPlugin().config.getStringList(type.toString().toUpperCase() + "_REWARDS");
-            if (follow_rewards == null || follow_rewards.isEmpty()) return null;
-            reward_list.add(new Reward(type, null, follow_rewards));
-        } else {
-            Set<String> keys = config_value.getKeys(false);
-            if (config_value == null || keys.size() == 0) return null;
-            Iterator<?> iterator = keys.iterator();
-            for (int i = 0; i < keys.size(); i++) {
-                String key = iterator.next().toString();
 
-                reward_list.add(new Reward(type, key, config_value.getStringList(key)));
+        if (type == rewardType.FOLLOW) {
+            if (config_rewards == null && config.getStringList(type.toString().toUpperCase() + "_REWARDS") != null) {
+                // Global events
+                reward_list.add(new Reward(type, EVERYONE, null, config.getStringList(type.toString().toUpperCase() + "_REWARDS")));
+            } else {
+                // Streamer specific events
+                Set<String> keys = config_rewards.getKeys(false);
+                for (String channel : keys) {
+                    reward_list.add(new Reward(type, channel.equals("default") ? EVERYONE : channel, null, config_rewards.getStringList(channel)));
+                }
             }
+            rewards.put(type, reward_list);
+            return reward_list;
+
+        } else if (config_rewards != null) {
+            Set<String> keys = config_rewards.getKeys(false);
+
+            for (String key : keys) {
+                ConfigurationSection channelSection = config_rewards.getConfigurationSection(key);
+                if (channelSection == null) {
+                    // No channel specified
+                    reward_list.add(new Reward(type, EVERYONE, key, config_rewards.getStringList(key)));
+                } else {
+                    // Streamer specific event
+                    Set<String> channelKeys = channelSection.getKeys(false);
+                    for (String channel : channelKeys) {
+                        reward_list.add(new Reward(type, channel.equals("default") ? EVERYONE : channel, key, channelSection.getStringList(channel)));
+                    }
+                }
+            }
+            rewards.put(type, reward_list);
+            return reward_list;
         }
 
-        rewards.put(type, reward_list);
-        return reward_list;
+        return null;
     }
 }

--- a/core/src/main/java/me/gosdev/chatpointsttv/Rewards/Rewards.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/Rewards/Rewards.java
@@ -63,9 +63,7 @@ public class Rewards {
             }
             reward_list.sort(new RewardComparator());
             rewards.put(type, reward_list);
-            for (Reward reward : reward_list) {
-                ChatPointsTTV.getPlugin().log.info(reward.getChannel()+": " + reward.getEvent());
-            }
+
             return reward_list;
         }
 

--- a/core/src/main/java/me/gosdev/chatpointsttv/TwitchAuth/AuthenticationCallbackRequest.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/TwitchAuth/AuthenticationCallbackRequest.java
@@ -102,6 +102,7 @@ public class AuthenticationCallbackRequest implements Runnable {
      *
      * @throws IOException
      */
+    @SuppressWarnings("null")
     private void processRequest() throws IOException {
         // Get a reference to the socket's input and output streams.
         @SuppressWarnings("unused")

--- a/core/src/main/java/me/gosdev/chatpointsttv/TwitchEventHandler.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/TwitchEventHandler.java
@@ -50,6 +50,7 @@ public class TwitchEventHandler {
                     plugin.log.warning(e.toString());
                 }
             }
+            return;
         }
     }
 
@@ -68,7 +69,7 @@ public class TwitchEventHandler {
                     plugin.log.warning(e.toString());
                 }
             }
-            return;       
+            return;    
         }
     }
 
@@ -89,14 +90,14 @@ public class TwitchEventHandler {
                 for (String cmd : reward.getCommands()) {
                     String[] parts = cmd.split(" ", 2);
                     try {
-                    Events.runAction(parts[0], parts[1], event.getChatterUserName());
+                        Events.runAction(parts[0], parts[1], event.getChatterUserName());
                     } catch (Exception e) {
                         plugin.log.warning(e.toString());
                     }
                 }
-                break;
+                return;
             }
-        } 
+        }
     }
 
     public void onSub(ChannelChatNotificationEvent event) {        
@@ -129,6 +130,7 @@ public class TwitchEventHandler {
                         plugin.log.warning(e.toString());
                     }
                 }
+                return;
             }
         }
     }
@@ -174,7 +176,7 @@ public class TwitchEventHandler {
                     plugin.log.warning(e.toString());
                 }
             }
-            break;
+            return;
         }
     }
 }

--- a/core/src/main/java/me/gosdev/chatpointsttv/TwitchEventHandler.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/TwitchEventHandler.java
@@ -30,8 +30,6 @@ public class TwitchEventHandler {
     ChatColor action_color = ChatPointsTTV.getChatColors().get("ACTION_COLOR");
     ChatColor user_color = ChatPointsTTV.getChatColors().get("USER_COLOR");
 
-    private Integer communitySubs = 0;
-
     public void onChannelPointsRedemption(RewardRedeemedEvent event) {
         
         if (logEvents) utils.sendMessage(Bukkit.getConsoleSender(), event.getRedemption().getUser().getDisplayName() + " has redeemed " + event.getRedemption().getReward().getTitle() + " in " + plugin.getUsername(event.getRedemption().getChannelId()));
@@ -137,30 +135,12 @@ public class TwitchEventHandler {
 
     public void onSubGift(ChannelChatNotificationEvent event) {       
         String chatter = event.getChatterUserName();
-        Integer amount;
-        String tier;
-
-        if (event.getNoticeType() == NoticeType.SUB_GIFT) {
-            amount = 1; // Single sub gift
-            tier = ChatPointsTTV.getUtils().PlanToString(event.getSubGift().getSubTier());
-
-            if (communitySubs > 0) {
-                communitySubs--;
-                return;
-            } 
-        } else if (event.getNoticeType() == NoticeType.COMMUNITY_SUB_GIFT) {
-            amount = event.getCommunitySubGift().getTotal();
-            tier = ChatPointsTTV.getUtils().PlanToString(event.getCommunitySubGift().getSubTier());
-            plugin.log.info(amount + " COMMUNITY SUB GIFTS!!!");
-
-            communitySubs += amount;
-        } else {
-            plugin.log.warning("Couldn't fetch gift type!");
-            return;
-        }
+        int amount = event.getCommunitySubGift().getTotal();
+        String tier = ChatPointsTTV.getUtils().PlanToString(event.getCommunitySubGift().getSubTier());
+        
+        plugin.log.info(amount + " COMMUNITY SUB GIFTS!!!");
 
         if (logEvents) utils.sendMessage(Bukkit.getConsoleSender(), event.getChatterUserName() + " has gifted " + amount  + " " + tier + " subs in " + event.getBroadcasterUserName() + "'s' channel!"); 
-
         String custom_string = ChatPointsTTV.getRedemptionStrings().get("GIFT_STRING");            
         ArrayList<Reward> rewards = Rewards.getRewards(rewardType.GIFT);
 

--- a/core/src/main/java/me/gosdev/chatpointsttv/TwitchEventHandler.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/TwitchEventHandler.java
@@ -9,13 +9,11 @@ import com.github.twitch4j.pubsub.domain.ChannelPointsRedemption;
 import com.github.twitch4j.pubsub.events.RewardRedeemedEvent;
 
 import me.gosdev.chatpointsttv.Rewards.Reward;
-import me.gosdev.chatpointsttv.Rewards.RewardComparator;
 import me.gosdev.chatpointsttv.Rewards.Rewards;
 import me.gosdev.chatpointsttv.Rewards.Rewards.rewardType;
 import me.gosdev.chatpointsttv.Utils.Utils;
 
 import java.util.ArrayList;
-import java.util.Collections;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -82,10 +80,7 @@ public class TwitchEventHandler {
         int amount = event.getCheer().getBits();
         String custom_string = ChatPointsTTV.getRedemptionStrings().get("CHEERED_STRING");
 
-        // Sort rewards by cheer.
         ArrayList<Reward> rewards = Rewards.getRewards(rewardType.CHEER);
-        Collections.sort(rewards, new RewardComparator());
-
         for (Reward reward : rewards) {
             if (!reward.getTargetId().equals(event.getBroadcasterUserId()) && !reward.getTargetId().equals(Rewards.EVERYONE)) continue;
 
@@ -166,7 +161,6 @@ public class TwitchEventHandler {
 
         String custom_string = ChatPointsTTV.getRedemptionStrings().get("GIFT_STRING");            
         ArrayList<Reward> rewards = Rewards.getRewards(rewardType.GIFT);
-        Collections.sort(rewards, new RewardComparator());
 
         Events.displayTitle(chatter, custom_string, amount + " " + tier + " subs", action_color, user_color, rewardBold);
         

--- a/core/src/main/java/me/gosdev/chatpointsttv/TwitchEventHandler.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/TwitchEventHandler.java
@@ -31,7 +31,6 @@ public class TwitchEventHandler {
     ChatColor user_color = ChatPointsTTV.getChatColors().get("USER_COLOR");
 
     public void onChannelPointsRedemption(RewardRedeemedEvent event) {
-        
         if (logEvents) utils.sendMessage(Bukkit.getConsoleSender(), event.getRedemption().getUser().getDisplayName() + " has redeemed " + event.getRedemption().getReward().getTitle() + " in " + plugin.getUsername(event.getRedemption().getChannelId()));
         ChannelPointsRedemption redemption = event.getRedemption();
         for (Reward reward : Rewards.getRewards(rewardType.CHANNEL_POINTS)) {

--- a/core/src/main/java/me/gosdev/chatpointsttv/TwitchEventHandler.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/TwitchEventHandler.java
@@ -58,7 +58,7 @@ public class TwitchEventHandler {
         String custom_string = ChatPointsTTV.getRedemptionStrings().get("FOLLOWED_STRING");
         Events.displayTitle(event.getUserName(), custom_string, "", action_color, user_color, rewardBold);
         for (Reward reward : Rewards.getRewards(rewardType.FOLLOW)) {
-            if (!reward.getTargetId().equals(event.getBroadcasterUserId())) continue;
+            if (!reward.getTargetId().equals(event.getBroadcasterUserId()) && !reward.getTargetId().equals(Rewards.EVERYONE)) continue;
 
             for (String cmd : reward.getCommands()) {
                 String[] parts = cmd.split(" ", 2);
@@ -84,7 +84,7 @@ public class TwitchEventHandler {
         Collections.sort(rewards, new RewardComparator());
 
         for (Reward reward : rewards) {
-            if (!reward.getTargetId().equals(event.getBroadcasterUserId())) continue;
+            if (!reward.getTargetId().equals(event.getBroadcasterUserId()) && !reward.getTargetId().equals(Rewards.EVERYONE)) continue;
 
             if (amount >= Integer.parseInt(reward.getEvent())) {
                 Events.displayTitle(chatter, custom_string, amount + " bits", action_color, user_color, rewardBold);
@@ -121,6 +121,7 @@ public class TwitchEventHandler {
 
         if (logEvents) utils.sendMessage(Bukkit.getConsoleSender(), event.getChatterUserName() + " subscribed with a " + ChatPointsTTV.getUtils().PlanToString(tier) + " sub to " + event.getBroadcasterUserName() + "!");
         for (Reward reward : Rewards.getRewards(rewardType.SUB)) {
+            if (!reward.getTargetId().equals(event.getBroadcasterUserId()) && !reward.getTargetId().equals(Rewards.EVERYONE)) continue;
 
             if (reward.getEvent().equals(ChatPointsTTV.getUtils().PlanToConfig(tier))) {
                 String custom_string = ChatPointsTTV.getRedemptionStrings().get("SUB_STRING");
@@ -153,6 +154,7 @@ public class TwitchEventHandler {
         Events.displayTitle(chatter, custom_string, amount + " " + tier + " subs", action_color, user_color, rewardBold);
         
         for (Reward reward : rewards) {
+            if (!reward.getTargetId().equals(event.getBroadcasterUserId()) && !reward.getTargetId().equals(Rewards.EVERYONE)) continue;
             for (String cmd : reward.getCommands()) {
                 String[] parts = cmd.split(" ", 2);
                 try {

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -1,6 +1,7 @@
 # This is the configuration file for ChatPointsTTV. For a fresh copy of this file, go to https://github.com/GospelBG/ChatPointsTTV/blob/master/src/main/resources/config.yml
 # For more information about how to use this file, refer to the config.yml instructions in the README file at https://github.com/GospelBG/ChatPointsTTV/blob/master/README.md
 
+# Username(s) of the streamer's channels. In case of multiple streamers, must be set as a list: ["channel_1", "channel_2", "..."]
 CHANNEL_USERNAME: {YOUR CHANNEL}
 
 # Uncomment the following lines (remove the # symbol at the start of the line) to use a key-based authentication instead of the browser login.

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -33,23 +33,26 @@ SHOW_CHAT: true
 # If your reward contains a text input, you can reference it as:
 #     {TEXT} **ONLY SUPPORTED ON CHANNEL POINTS**
 
+# To add a streamer-specific reward add the actions inside a list named as the desired channel.
+# To target all channels use "default" as the list key.
+
 # Leave any reward class empty to disable it.
 CHANNEL_POINTS_REWARDS:
   [REWARD NAME]:
     - {ACTION 1}
     - {ACTION 2}
 
-# Put the desired action after the colon in the form of a list. You musn't add a "Reward Name".
+# Put the desired action after the colon as a list. You musn't add a "Reward Name".
 FOLLOW_REWARDS:
   - {ACTION}
   - {ACTION}
 
-# Follow the same format as the Channel Point Rewards, replacing the name of the reward for the minimum ammount of bits that needs to be cheered.
+# Follow the same format as Channel Point Rewards, replacing the name of the reward for the minimum ammount of bits that needs to be cheered.
 CHEER_REWARDS:
   [BITS AMOUNT]:
     - {ACTION}
 
-# Follow the same format as the Channel Point Rewards, replacing the name of the reward for the desired sub tier: TWITCH_PRIME/TIER1/TIER2/TIER3.
+# Follow the same format as Channel Point Rewards, replacing the name of the reward for the desired sub tier: TWITCH_PRIME/TIER1/TIER2/TIER3.
 # Also you can enter an AMOUNT on GIFT_REWARDS to toggle actions with sub gifting
 SUB_REWARDS:
   [TWITCH_PRIME]:

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>me.gosdev</groupId>
   <artifactId>chatpointsttv-dist</artifactId>


### PR DESCRIPTION
· You can now add multiple channels in the `CHANNEL_USERNAME` field as a string list.
· You can add to a section named as one of the streamers you are listening to all rewards targeted exclusively to them or use the `default` or `*` wildcard (See README for examples).
· Fixed some API related bugs