### PR TITLE
Improvement/ingame alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You need to follow this format: `AMOUNT: {ACTION}`, replacing `AMOUNT` with the 
 * **Mob Glow**: Whether the spawned mobs should have a glowing effect (highlighted and visible through blocks).
 * **Display Name on Mob**: Whether the spawned mobs should have the name of the user who triggered the action.
 * **Log Event**: Determines whether all events will be logged. `true` means that all channel point rewards, cheers, subscriptions and gifts will be logged into the console. `false` means that they won't be logged.
-* **Show In-game Alerts**: Determines whether subscribed events should show an in-game title message.
+* **In-game Alerts Mode***: How will the game notify of an event. Valid options: `chat`, `title`, `all`, `none`. Choosing `none`  will disable In-game alerts.
 * **Reward Name Bold**: Determines whether the reward name is displayed in bold letters in the title banner to people with the `chatpointsttv.broadcast` permission.
 * **Colors**: Allows you to customize every color of the title messages. Set the wanted strings to any Minecraft Color Name (`RED`, `GOLD`, `DARK_PURPLE`...).  
 You can leave this section unmodified, as there are default colors set up in the original file

--- a/core/src/main/java/me/gosdev/chatpointsttv/ChatPointsTTV.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/ChatPointsTTV.java
@@ -72,7 +72,7 @@ public class ChatPointsTTV extends JavaPlugin {
     public static Boolean customCredentials = false;
     public static Boolean shouldMobsGlow;
     public static Boolean nameSpawnedMobs;
-    public static Boolean enableAlerts;
+    public static alert_mode alertMode;
     private List<String> chatBlacklist;
     public static boolean configOk = true;
     public Thread linkThread;
@@ -108,6 +108,13 @@ public class ChatPointsTTV extends JavaPlugin {
         private permissions(String label) {
             this.permission_id = label;
         }
+    }
+
+    public static enum alert_mode {
+        NONE,
+        CHAT,
+        TITLE,
+        ALL
     }
 
     public static ChatPointsTTV getPlugin() {
@@ -195,10 +202,6 @@ public class ChatPointsTTV extends JavaPlugin {
             } else {
                 configOk = true;
             }
-        } catch (Exception e) {
-            configOk = false;
-            log.warning(e.getMessage());
-        }
 
 
         if (config.getString("CUSTOM_CLIENT_ID") != null || config.getString("CUSTOM_CLIENT_SECRET") != null) customCredentials = true;
@@ -214,9 +217,13 @@ public class ChatPointsTTV extends JavaPlugin {
         TwitchEventHandler.rewardBold = config.getBoolean("REWARD_NAME_BOLD");
 
         shouldMobsGlow = config.getBoolean("MOB_GLOW", false);
-        enableAlerts = config.getBoolean("SHOW_INGAME_ALERTS", true);
+        alertMode = alert_mode.valueOf(config.getString("INGAME_ALERTS").toUpperCase());
         nameSpawnedMobs = config.getBoolean("DISPLAY_NAME_ON_MOB", true);
         chatBlacklist = config.getStringList("CHAT_BLACKLIST");
+    } catch (Exception e) {
+        configOk = false;
+        log.warning("There was an error reading config.yml");
+    }
 
         cmdController = new CommandController();
         this.getCommand("twitch").setExecutor(cmdController);

--- a/core/src/main/java/me/gosdev/chatpointsttv/Events.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/Events.java
@@ -10,23 +10,51 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
 
+import me.gosdev.chatpointsttv.ChatPointsTTV.alert_mode;
 import me.gosdev.chatpointsttv.ChatPointsTTV.permissions;
 import me.gosdev.chatpointsttv.Utils.SpawnRunnable;
 import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.chat.ComponentBuilder;
 
 import org.bukkit.entity.EntityType;
 
 public class Events {
     static ChatPointsTTV plugin = ChatPointsTTV.getPlugin();
     static Logger log = plugin.log;
+    public static void setAlertMode(alert_mode alertMode) {
+        ChatPointsTTV.alertMode = alertMode;
+    }
 
-    public static void displayTitle(String user, String action, String rewardName, ChatColor titleColor, ChatColor userColor, Boolean isBold) {
-        if (!ChatPointsTTV.enableAlerts) return; // Do not show alerts if user has disabled them.
-        plugin.getServer().getOnlinePlayers().forEach (p -> {
-            if (p.hasPermission(ChatPointsTTV.permissions.BROADCAST.permission_id)) {
-                ChatPointsTTV.getUtils().displayTitle(p.getPlayer(), user, action, rewardName, isBold, userColor, titleColor);
-            }
-        });
+    public static void showIngameAlert(String user, String action, String rewardName, ChatColor titleColor, ChatColor userColor, Boolean isBold) {
+        ComponentBuilder builder = new ComponentBuilder(user).color(userColor).bold(isBold);
+        builder.append(" " + action).color(titleColor);
+        builder.append(" " + rewardName).color(userColor);
+
+        switch (ChatPointsTTV.alertMode) {
+            case CHAT:
+                for (Player p : Bukkit.getOnlinePlayers()) {
+                    if (!p.hasPermission(ChatPointsTTV.permissions.BROADCAST.permission_id)) continue;
+                    ChatPointsTTV.getUtils().sendMessage(p, builder.create());
+                }
+                break;
+            case TITLE:
+                for (Player p : Bukkit.getOnlinePlayers()) {
+                    if (!p.hasPermission(ChatPointsTTV.permissions.BROADCAST.permission_id)) continue;
+                    ChatPointsTTV.getUtils().displayTitle(p.getPlayer(), user, action, rewardName, isBold, userColor, titleColor);
+                };
+                break;
+
+            case ALL:
+                for (Player p : Bukkit.getOnlinePlayers()) {
+                    if (!p.hasPermission(ChatPointsTTV.permissions.BROADCAST.permission_id)) continue;
+                    ChatPointsTTV.getUtils().sendMessage(p, builder.create());
+                    ChatPointsTTV.getUtils().displayTitle(p.getPlayer(), user, action, rewardName, isBold, userColor, titleColor);
+                }
+                break;
+                
+            default:
+                return;                
+        }
     }
 
     public static void runAction(String action, String args, String user) throws Exception {

--- a/core/src/main/java/me/gosdev/chatpointsttv/Events.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/Events.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.logging.Logger;
 
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -13,6 +12,7 @@ import org.bukkit.scheduler.BukkitRunnable;
 
 import me.gosdev.chatpointsttv.ChatPointsTTV.permissions;
 import me.gosdev.chatpointsttv.Utils.SpawnRunnable;
+import net.md_5.bungee.api.ChatColor;
 
 import org.bukkit.entity.EntityType;
 

--- a/core/src/main/java/me/gosdev/chatpointsttv/TwitchEventHandler.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/TwitchEventHandler.java
@@ -13,12 +13,12 @@ import me.gosdev.chatpointsttv.Rewards.RewardComparator;
 import me.gosdev.chatpointsttv.Rewards.Rewards;
 import me.gosdev.chatpointsttv.Rewards.Rewards.rewardType;
 import me.gosdev.chatpointsttv.Utils.Utils;
+import net.md_5.bungee.api.ChatColor;
 
 import java.util.ArrayList;
 import java.util.Collections;
 
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 
 public class TwitchEventHandler {
     ChatPointsTTV plugin = ChatPointsTTV.getPlugin();
@@ -29,8 +29,8 @@ public class TwitchEventHandler {
     Boolean listenForSubs = !plugin.config.getConfigurationSection("SUB_REWARDS").getKeys(true).isEmpty();
     Boolean listenForGifts = !plugin.config.getConfigurationSection("GIFT_REWARDS").getKeys(true).isEmpty();
     Boolean logEvents = plugin.config.getBoolean("LOG_EVENTS");
-    ChatColor action_color = ChatPointsTTV.getChatColors().get("ACTION_COLOR");
-    ChatColor user_color = ChatPointsTTV.getChatColors().get("USER_COLOR");
+    ChatColor action_color = ChatPointsTTV.getChatColors().get("ACTION_COLOR").asBungee();
+    ChatColor user_color = ChatPointsTTV.getChatColors().get("USER_COLOR").asBungee();
 
     private Integer ignoreSubs = 0;
 
@@ -41,7 +41,7 @@ public class TwitchEventHandler {
         for (Reward reward : Rewards.getRewards(rewardType.CHANNEL_POINTS)) {
             if (!reward.getEvent().equalsIgnoreCase(redemption.getReward().getTitle())) continue;
             String custom_string = ChatPointsTTV.getRedemptionStrings().get("REDEEMED_STRING");
-            Events.displayTitle(redemption.getUser().getDisplayName(), custom_string, redemption.getReward().getTitle(), action_color, user_color, rewardBold);
+            Events.showIngameAlert(redemption.getUser().getDisplayName(), custom_string, redemption.getReward().getTitle(), action_color, user_color, rewardBold);
             for (String cmd : reward.getCommands()) {
                 String[] parts = cmd.split(" ", 2);
                 try {
@@ -56,7 +56,7 @@ public class TwitchEventHandler {
     public void onFollow(ChannelFollowEvent event) {
         if (logEvents) utils.sendMessage(Bukkit.getConsoleSender(), event.getUserName() + " started following you");
         String custom_string = ChatPointsTTV.getRedemptionStrings().get("FOLLOWED_STRING");
-        Events.displayTitle(event.getUserName(), custom_string, "", action_color, user_color, rewardBold);
+        Events.showIngameAlert(event.getUserName(), custom_string, "", action_color, user_color, rewardBold);
         for (String cmd : Rewards.getRewards(rewardType.FOLLOW).get(0).getCommands()) {
             String[] parts = cmd.split(" ", 2);
             try {
@@ -82,7 +82,7 @@ public class TwitchEventHandler {
 
         for (Reward i : rewards) {
             if (amount >= Integer.parseInt(i.getEvent())) {
-                Events.displayTitle(chatter, custom_string, amount + " bits", action_color, user_color, rewardBold);
+                Events.showIngameAlert(chatter, custom_string, amount + " bits", action_color, user_color, rewardBold);
                 for (String cmd : i.getCommands()) {
                     String[] parts = cmd.split(" ", 2);
                     try {
@@ -115,7 +115,7 @@ public class TwitchEventHandler {
             
             for (Reward i : rewards) {
                 if (amount >= Integer.parseInt(i.getEvent())) {
-                    Events.displayTitle(chatter, custom_string, amount + " " + tier + " subs", action_color, user_color, rewardBold);
+                    Events.showIngameAlert(chatter, custom_string, amount + " " + tier + " subs", action_color, user_color, rewardBold);
                     for (String cmd : i.getCommands()) {
                         String[] parts = cmd.split(" ", 2);
                         try {
@@ -152,7 +152,7 @@ public class TwitchEventHandler {
                 if (i.getEvent().equals(ChatPointsTTV.getUtils().PlanToConfig(tier))) {
                     String custom_string = ChatPointsTTV.getRedemptionStrings().get("SUB_STRING");
                     
-                    Events.displayTitle(event.getChatterUserName(), custom_string, ChatPointsTTV.getUtils().PlanToString(tier), action_color, user_color, rewardBold);
+                    Events.showIngameAlert(event.getChatterUserName(), custom_string, ChatPointsTTV.getUtils().PlanToString(tier), action_color, user_color, rewardBold);
                     for (String cmd : i.getCommands()) {
                         String[] parts = cmd.split(" ", 2);
                         try {

--- a/core/src/main/java/me/gosdev/chatpointsttv/Utils/Utils.java
+++ b/core/src/main/java/me/gosdev/chatpointsttv/Utils/Utils.java
@@ -1,11 +1,11 @@
 package me.gosdev.chatpointsttv.Utils;
 
-import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import com.github.twitch4j.common.enums.SubscriptionPlan;
 
+import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
 
 public interface Utils {

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -68,10 +68,12 @@ DISPLAY_NAME_ON_MOB: true
 # Whether the plugin should log to the console when a user (GospelBG cheered 300 bits!; GospelBG has subscribed with a Tier 1 sub!; ...)
 LOG_EVENTS: true
 
-# Customize the in-game title.
-
-# Toggles in-game title messages.
-SHOW_INGAME_ALERTS: true
+# In-game event alerts mode.
+#     none: Disables in-game alerts
+#     chat: Displays a message in the chat
+#     title: Shows a title splash message
+#     all: Uses both "chat" and "title" alerts
+INGAME_ALERTS: chat
 
 # You can use the following options:
 

--- a/craftbukkit_1_12_R1/src/main/java/me/gosdev/chatpointsttv/Utils/Utils_1_12_R1.java
+++ b/craftbukkit_1_12_R1/src/main/java/me/gosdev/chatpointsttv/Utils/Utils_1_12_R1.java
@@ -1,14 +1,13 @@
 package me.gosdev.chatpointsttv.Utils;
 
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import com.github.twitch4j.common.enums.SubscriptionPlan;
 
 import me.gosdev.chatpointsttv.ChatPointsTTV;
-
+import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 

--- a/craftbukkit_1_9_R1/src/main/java/me/gosdev/chatpointsttv/Utils/Utils_1_9_R1.java
+++ b/craftbukkit_1_9_R1/src/main/java/me/gosdev/chatpointsttv/Utils/Utils_1_9_R1.java
@@ -1,13 +1,13 @@
 package me.gosdev.chatpointsttv.Utils;
 
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import com.github.twitch4j.common.enums.SubscriptionPlan;
 
 import me.gosdev.chatpointsttv.ChatPointsTTV;
+import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 


### PR DESCRIPTION
· Replaced `SHOW_INGAME_ALERTS` to `INGAME_ALERTS`, which now allow to customize in-game alerts.
Valid options:

- Chat: will send a message to all players with the `chatpointsttv.broadcast` permission.
- Title: will display an on-screen title to all players with the `chatpointsttv.broadcast` permission. This was the method used previously.
- All: enables both `chat` and `title` options.
- None: disables in-game alerts